### PR TITLE
Move url-configuration-directory to var

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -211,8 +211,8 @@ This variable has to be set before `no-littering' is loaded.")
     (setq shared-game-score-directory      (var "shared-game-score/"))
     (setq tramp-persistency-file-name      (var "tramp-persistency.el"))
     (setq trash-directory                  (var "trash/"))
-    (setq url-cache-directory              (var "url/"))
-    (setq url-configuration-directory      (etc "url/"))
+    (setq url-cache-directory              (var "url/cache/"))
+    (setq url-configuration-directory      (var "url/"))
 
 ;;; Third-party packages
 


### PR DESCRIPTION
I think `url-configuration-directory` should be set to a `var` directory, rather than `etc`. Despite having "configuration" in the name, what gets stored there is things like cookies and history. That seems more like cache state than configuration.

I propose using var/url and var/url/cache, but perhaps it would be more consistent with the no-littering guidelines to have var/url/configuration and var/url/cache. 