### PR TITLE
Correct a typographical error in the package conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Conventions
   
 2. If a package has multiple data (or config files), then those files
    are placed in a subdirectory of `no-littering-var-directory` (or
-   `no-littering-var-directory`).
+   `no-littering-etc-directory`).
   
 3. If a subdirectory is used for a package's data (or config) file
    variables, then the name of the directory should match the name of

--- a/no-littering.el
+++ b/no-littering.el
@@ -68,7 +68,7 @@
 
 ;; * File names
 ;;
-;; 1. File names are based on the name of the respective Emacs lisp
+;; 1. File names are based on the name of the respective Emacs Lisp
 ;;    variables and the name of the respective Emacs package.
 ;;
 ;; 2. The name of the respective Emacs package should serve as the
@@ -97,11 +97,11 @@
 ;;
 ;; 2. If a package has multiple data (or config files), then those files
 ;;    are placed in a subdirectory of `no-littering-var-directory` (or
-;;    `no-littering-var-directory`).
+;;    `no-littering-etc-directory`).
 ;;
 ;; 3. If a subdirectory is used for a package's data (or config) file
 ;;    variables, then the name of the directory should match the name of
-;;    the package in most cases. The subdirectory name may serve as the
+;;    the package in most cases.  The subdirectory name may serve as the
 ;;    package prefix of the file name.
 ;;
 ;; 4. A package that provides a "framework" for other packages to use,


### PR DESCRIPTION
Correction applied to both the Emacs Lisp and Markdown files. Removed some
trivial errors highlighted by Flycheck as well.